### PR TITLE
Added option to load choices from context or set with a msg, added a refresh option in conjunction

### DIFF
--- a/fuzzywuzzy.html
+++ b/fuzzywuzzy.html
@@ -4,6 +4,9 @@
         color: '#FFAAAA',
         defaults: {
             name: { value: "" },
+            inputOptions : { value: "text" },
+            contextType : { value:"flow" },
+            contextInput : { value:"" },
             choices : { value: "" },
             scorer : { value : 'WRatio' }, // scorer function
             limit: { value: '0', validate:RED.validators.number() }, // Max number of top results to return, default: no limit / 0.
@@ -21,7 +24,22 @@
             id: 'node-input-choices-editor',
             mode: 'ace/mode/text',
             value: this.choices
-          })
+          });
+          $("#node-input-contextInput").typedInput({
+            type:"msg",
+            types:["flow","global"],
+            typeField: "#node-input-contextType"
+          });
+          $("#node-input-inputOptions").on("change", function(){
+            let option = $("#node-input-inputOptions").val();
+            if(option == "text"){
+                $("#contextField").hide();
+                $("#textField").show();
+            } else {
+                $("#contextField").show();
+                $("#textField").hide();
+            }
+          });
         },
         oneditsave: function() {
           this.choices = this.editor.getValue()
@@ -41,6 +59,18 @@
       <input type="text" id="node-input-name" placeholder="Name">
   </div>
   <div class="form-row">
+    <label for="node-input-inputOptions">Source</label>
+    <select id="node-input-inputOptions" style="width:270px !important">
+        <option value="text">enter choices in node</option>
+        <option value="context">load choices from context</option>
+    </select>
+  </div>
+  <div class="form-row" id="contextField">
+    <label for="node-input-contextInput">Choices</label>
+    <input type="text" id="node-input-contextInput">
+    <input type="hidden" id="node-input-contextType">
+  </div>
+  <div class="form-row" id="textField">
     <label for="node-input-choices-editor">Choices</label>
     <div style="height: 250px; min-height:150px;" class="node-text-editor" id="node-input-choices-editor"></div>
   </div>

--- a/fuzzywuzzy.html
+++ b/fuzzywuzzy.html
@@ -5,8 +5,6 @@
         defaults: {
             name: { value: "" },
             inputOptions : { value: "text" },
-            contextType : { value:"flow" },
-            contextInput : { value:"" },
             choices : { value: "" },
             scorer : { value : 'WRatio' }, // scorer function
             limit: { value: '0', validate:RED.validators.number() }, // Max number of top results to return, default: no limit / 0.
@@ -33,13 +31,8 @@
           $("#node-input-inputOptions").on("change", function(){
             let option = $("#node-input-inputOptions").val();
             if(option == "text"){
-                $("#contextField").hide();
                 $("#textField").show();
-            } else if (option == "context") {
-                $("#contextField").show();
-                $("#textField").hide();
             } else if (option == "message") {
-                $("#contextField").hide();
                 $("#textField").hide();
             }
           });
@@ -65,14 +58,8 @@
     <label for="node-input-inputOptions">Source</label>
     <select id="node-input-inputOptions" style="width:270px !important">
         <option value="text">enter choices in node</option>
-        <option value="context">load choices from context</option>
         <option value="message">set choices with msg.payload</option>
     </select>
-  </div>
-  <div class="form-row" id="contextField">
-    <label for="node-input-contextInput">Choices</label>
-    <input type="text" id="node-input-contextInput">
-    <input type="hidden" id="node-input-contextType">
   </div>
   <div class="form-row" id="textField">
     <label for="node-input-choices-editor">Choices</label>

--- a/fuzzywuzzy.html
+++ b/fuzzywuzzy.html
@@ -23,11 +23,6 @@
             mode: 'ace/mode/text',
             value: this.choices
           });
-          $("#node-input-contextInput").typedInput({
-            type:"msg",
-            types:["flow","global"],
-            typeField: "#node-input-contextType"
-          });
           $("#node-input-inputOptions").on("change", function(){
             let option = $("#node-input-inputOptions").val();
             if(option == "text"){

--- a/fuzzywuzzy.html
+++ b/fuzzywuzzy.html
@@ -35,8 +35,11 @@
             if(option == "text"){
                 $("#contextField").hide();
                 $("#textField").show();
-            } else {
+            } else if (option == "context") {
                 $("#contextField").show();
+                $("#textField").hide();
+            } else if (option == "message") {
+                $("#contextField").hide();
                 $("#textField").hide();
             }
           });
@@ -63,6 +66,7 @@
     <select id="node-input-inputOptions" style="width:270px !important">
         <option value="text">enter choices in node</option>
         <option value="context">load choices from context</option>
+        <option value="message">set choices with msg.payload</option>
     </select>
   </div>
   <div class="form-row" id="contextField">

--- a/fuzzywuzzy.js
+++ b/fuzzywuzzy.js
@@ -30,6 +30,8 @@ module.exports = function(RED) {
               return gotContext;
           } else if (config.inputOptions === "text") {
               return config.choices;
+          } else if (config.inputOptions === "message") {
+              return "";
           }
       }
       
@@ -68,10 +70,22 @@ module.exports = function(RED) {
 
       node.on('input', function(msg) {
           
-          if (msg.refresh) {
-              input = getInput();
+          if (msg.refresh && config.inputOptions !== "text") {
+              if (config.inputOptions !== "message") {
+                  input = getInput();
+              } else {
+                  if (typeof msg.payload !== "string") {
+                      node.error('when in "set choices with msg" mode a msg with msg.refresh set must be accompanied by the choices to be set as a single string');
+                      return;
+                  }
+                  input = msg.payload;
+              }
               keyChoicePairs = makeChoices(input);
-              node.warn("refreshed choices");
+              if (config.inputOptions === "context") {
+                  node.warn(`refreshed choices from ${config.contextType}.${config.contextInput}`);
+              } else if (config.inputOptions === "message") {
+                  node.warn("refreshed choices from msg.payload");
+              }
               return;
           }
           

--- a/fuzzywuzzy.js
+++ b/fuzzywuzzy.js
@@ -7,28 +7,7 @@ module.exports = function(RED) {
       
       // get content from choosen input option
       function getInput () {
-          if (config.inputOptions === "context") {
-              let gotContext = "";
-              if (config.contextInput.length < 1) { node.error("please enter a context var"); return ""; }
-              try {
-                  switch (config.contextType) {
-                      case "flow":
-                          const flowContext = node.context().flow;
-                          gotContext = flowContext.get(config.contextInput);
-                          break;
-                        
-                      case "global":
-                          const globalContext = node.context().global;
-                          gotContext = globalContext.get(config.contextInput);
-                          break;
-                  }
-              } catch (error) {
-                  node.error(`couldnt retrieve choices from context: ${error}`);
-                  return "";
-              }
-              if (!gotContext) { node.error("please enter a valid context var"); return ""; }
-              return gotContext;
-          } else if (config.inputOptions === "text") {
+          if (config.inputOptions === "text") {
               return config.choices;
           } else if (config.inputOptions === "message") {
               return "";
@@ -71,21 +50,13 @@ module.exports = function(RED) {
       node.on('input', function(msg) {
           
           if (msg.refresh && config.inputOptions !== "text") {
-              if (config.inputOptions !== "message") {
-                  input = getInput();
-              } else {
-                  if (typeof msg.payload !== "string") {
-                      node.error('when in "set choices with msg" mode a msg with msg.refresh set must be accompanied by the choices to be set as a single string');
-                      return;
-                  }
-                  input = msg.payload;
+              if (typeof msg.payload !== "string") {
+                  node.error('when in "set choices with msg" mode a msg with msg.refresh set must be accompanied by the choices to be set as a single string');
+                  return;
               }
+              input = msg.payload;
               keyChoicePairs = makeChoices(input);
-              if (config.inputOptions === "context") {
-                  node.warn(`refreshed choices from ${config.contextType}.${config.contextInput}`);
-              } else if (config.inputOptions === "message") {
-                  node.warn("refreshed choices from msg.payload");
-              }
+              node.warn("refreshed choices from msg.payload");
               return;
           }
           


### PR DESCRIPTION
Hello,
First of thanks for the great node. I worked with fuzzball js before for intent recognition and had a node for this on my own back log.
So I’m happy you did all the hard work making one 👍
As I have generated intent lists with over 10000 lines in external files that I wanted to use with your node I propose this addition as implemented in my pull request.
The additions would add the option to load the choices from a context var in addition to the current option of adding them in the nodes ui directly.
I also added a refresh function in conjunction with this. If you send a `msg` with a refresh property it will reload the choices. This allows for flows where on start up or when a file/context variable is changed those changes can be propagated to the choices.
I hope you don’t mind this uninvited pull request and I would be happy if you could take a look at it.

best regards from Berlin, Johannes